### PR TITLE
Replace deprecated wfMsgForContent functions

### DIFF
--- a/Duoshuo/Duoshuo.php
+++ b/Duoshuo/Duoshuo.php
@@ -93,9 +93,9 @@ class Duoshuo{
 			die(1);
 		}
 	
-		$data .= wfMsgForContent('duoshuo-before')
+		$data .= wfMessage('duoshuo-before')->inContentLanguage()->text()
 			. '<div class="ds-thread" data-thread-key="' . $wgTitle->getArticleID() . '" data-title="' . $wgTitle->getPrefixedText() . '" data-url="' . $wgTitle->getFullURL() . '"></div>'
-			. wfMsgForContent('duoshuo-after');
+			. wfMessage('duoshuo-after')->inContentLanguage()->text();
 		return true;
 	}
 	


### PR DESCRIPTION
MediaWiki在1.27中移除了 wfMsg\* 函数。
https://www.mediawiki.org/wiki/Manual:Messages_API#Help_with_replacing_deprecated_wfMsg.2A_functions
